### PR TITLE
[FEATURE] 댓글 리스트 조회

### DIFF
--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/ReplyController.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/ReplyController.java
@@ -1,20 +1,25 @@
 package com.hyundai.hmingle.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hyundai.hmingle.controller.dto.request.ReplyCreateRequest;
 import com.hyundai.hmingle.controller.dto.request.ReplyUpdateRequest;
 import com.hyundai.hmingle.controller.dto.response.MingleResponse;
 import com.hyundai.hmingle.controller.dto.response.ReplyCreateResponse;
+import com.hyundai.hmingle.controller.dto.response.ReplyDetailResponse;
 import com.hyundai.hmingle.controller.dto.response.ReplyUpdateResponse;
 import com.hyundai.hmingle.service.ReplyService;
 import com.hyundai.hmingle.support.JwtTokenExtractor;
@@ -67,6 +72,19 @@ public class ReplyController {
 		return ResponseEntity.ok(MingleResponse.success(
 			"댓글 삭제에 성공하였습니다.",
 			null
+		));
+	}
+
+	@GetMapping
+	public ResponseEntity<MingleResponse<List<ReplyDetailResponse>>> findAllWithPaging(
+		@PathVariable Long postId,
+		@RequestParam Integer page,
+		@RequestParam Integer size,
+		@RequestParam(required = false) Long parentId) {
+		List<ReplyDetailResponse> responses = replyService.findAllWithPaging(postId, page, size, parentId);
+		return ResponseEntity.ok(MingleResponse.success(
+			"댓글 목록 조회에 성공하였습니다.",
+			responses
 		));
 	}
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/ReplyDetailResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/ReplyDetailResponse.java
@@ -1,0 +1,16 @@
+package com.hyundai.hmingle.controller.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReplyDetailResponse {
+
+	private final Long id;
+	private final String nickname;
+	private final String content;
+	private final int like;
+	private final String recent;
+	private final Long parentId;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/domain/post/ReplyHeart.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/domain/post/ReplyHeart.java
@@ -1,0 +1,18 @@
+package com.hyundai.hmingle.domain.post;
+
+import org.springframework.stereotype.Component;
+
+import com.hyundai.hmingle.domain.common.Base;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReplyHeart extends Base {
+
+	private Integer replyId;
+	private Integer memberId;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ReplyMapper.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ReplyMapper.java
@@ -17,7 +17,7 @@ public interface ReplyMapper {
 
 	List<ReplyResponse> findAll(RepliesRequest request);
 
-	List<ReplyResponse> findAllIfParentIsNull(Long postId);
+	List<ReplyResponse> findAllIfParentIsNull(RepliesRequest request);
 
 	void save(ReplyCreateDto reply);
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ReplyMapper.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ReplyMapper.java
@@ -3,7 +3,9 @@ package com.hyundai.hmingle.mapper;
 import java.util.List;
 import java.util.Optional;
 
+import com.hyundai.hmingle.mapper.dto.response.ReplyResponse;
 import com.hyundai.hmingle.domain.post.Reply;
+import com.hyundai.hmingle.mapper.dto.request.RepliesRequest;
 import com.hyundai.hmingle.mapper.dto.request.ReplyCreateDto;
 import com.hyundai.hmingle.mapper.dto.request.ReplyUpdateDto;
 
@@ -12,6 +14,10 @@ public interface ReplyMapper {
 	Optional<Reply> findById(Long id);
 
 	List<Reply> findAllByPostId(Long postId);
+
+	List<ReplyResponse> findAll(RepliesRequest request);
+
+	List<ReplyResponse> findAllIfParentIsNull(Long postId);
 
 	void save(ReplyCreateDto reply);
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/RepliesRequest.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/RepliesRequest.java
@@ -1,0 +1,12 @@
+package com.hyundai.hmingle.mapper.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RepliesRequest {
+
+	private final Long postId;
+	private final Long parentId;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/RepliesRequest.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/RepliesRequest.java
@@ -1,12 +1,14 @@
 package com.hyundai.hmingle.mapper.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class RepliesRequest {
 
 	private final Long postId;
 	private final Long parentId;
+	private final int startRow;
+	private final int size;
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
@@ -1,0 +1,15 @@
+package com.hyundai.hmingle.mapper.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReplyResponse {
+
+	private Long id;
+	private String nickname;
+	private String content;
+	private Long parentId;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
@@ -12,4 +12,5 @@ public class ReplyResponse {
 	private String nickname;
 	private String content;
 	private Long parentId;
+	private int heartCount;
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
@@ -1,5 +1,7 @@
 package com.hyundai.hmingle.mapper.dto.response;
 
+import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,4 +15,5 @@ public class ReplyResponse {
 	private String content;
 	private Long parentId;
 	private int heartCount;
+	private LocalDateTime createDate;
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
@@ -61,7 +61,7 @@ public class ReplyRepository {
 
 	public List<ReplyResponse> findAll(RepliesRequest request) {
 		if (request.getParentId() == null) {
-			return replyMapper.findAllIfParentIsNull(request.getPostId());
+			return replyMapper.findAllIfParentIsNull(request);
 		}
 		return replyMapper.findAll(request);
 	}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
@@ -2,7 +2,6 @@ package com.hyundai.hmingle.repository;
 
 import org.springframework.stereotype.Repository;
 
-import com.hyundai.hmingle.controller.dto.request.ReplyCreateRequest;
 import com.hyundai.hmingle.domain.member.Member;
 import com.hyundai.hmingle.domain.post.Post;
 import com.hyundai.hmingle.domain.post.Reply;
@@ -45,19 +44,19 @@ public class ReplyRepository {
 			.orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
 	}
 
-	public Reply findParentById(ReplyCreateRequest request) {
-		if (request.getParentId() == null) {
+	public Reply findParentByParentId(Long parentId) {
+		if (parentId == null) {
 			return null;
 		}
-		Reply parentReply = findByParentId(request);
+		Reply parentReply = findByParentId(parentId);
 		if (parentReply.getDepth() > 0) {
 			throw new RuntimeException("댓글의 depth 는 최대 1 입니다.");
 		}
 		return parentReply;
 	}
 
-	private Reply findByParentId(ReplyCreateRequest request) {
-		return replyMapper.findById(request.getParentId())
+	private Reply findByParentId(Long parentId) {
+		return replyMapper.findById(parentId)
 			.orElseThrow(() -> new RuntimeException("존재하지 않는 상위 댓글입니다."));
 	}
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ReplyRepository.java
@@ -1,13 +1,17 @@
 package com.hyundai.hmingle.repository;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.hyundai.hmingle.domain.member.Member;
 import com.hyundai.hmingle.domain.post.Post;
 import com.hyundai.hmingle.domain.post.Reply;
 import com.hyundai.hmingle.mapper.ReplyMapper;
+import com.hyundai.hmingle.mapper.dto.request.RepliesRequest;
 import com.hyundai.hmingle.mapper.dto.request.ReplyCreateDto;
 import com.hyundai.hmingle.mapper.dto.request.ReplyUpdateDto;
+import com.hyundai.hmingle.mapper.dto.response.ReplyResponse;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +57,13 @@ public class ReplyRepository {
 			throw new RuntimeException("댓글의 depth 는 최대 1 입니다.");
 		}
 		return parentReply;
+	}
+
+	public List<ReplyResponse> findAll(RepliesRequest request) {
+		if (request.getParentId() == null) {
+			return replyMapper.findAllIfParentIsNull(request.getPostId());
+		}
+		return replyMapper.findAll(request);
 	}
 
 	private Reply findByParentId(Long parentId) {

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
@@ -78,7 +78,7 @@ public class ReplyService {
 
 		return replies.stream()
 			.map(reply -> new ReplyDetailResponse(
-				reply.getId(), reply.getNickname(), reply.getContent(), 0, "", null))
+				reply.getId(), reply.getNickname(), reply.getContent(), reply.getHeartCount(), "", null))
 			.collect(Collectors.toUnmodifiableList());
 	}
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
@@ -19,6 +19,7 @@ import com.hyundai.hmingle.mapper.dto.response.ReplyResponse;
 import com.hyundai.hmingle.repository.MemberRepository;
 import com.hyundai.hmingle.repository.PostRepository;
 import com.hyundai.hmingle.repository.ReplyRepository;
+import com.hyundai.hmingle.support.DateTimeConvertor;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class ReplyService {
 	private final MemberRepository memberRepository;
 	private final PostRepository postRepository;
 	private final ReplyRepository replyRepository;
+	private final DateTimeConvertor dateTimeConvertor;
 
 	public ReplyCreateResponse save(Long memberId, Long postId, ReplyCreateRequest request) {
 		Member savedMember = memberRepository.findById(memberId);
@@ -78,7 +80,8 @@ public class ReplyService {
 
 		return replies.stream()
 			.map(reply -> new ReplyDetailResponse(
-				reply.getId(), reply.getNickname(), reply.getContent(), reply.getHeartCount(), "", null))
+				reply.getId(), reply.getNickname(), reply.getContent(), reply.getHeartCount(),
+				dateTimeConvertor.calculate(reply.getCreateDate()), null))
 			.collect(Collectors.toUnmodifiableList());
 	}
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
@@ -69,13 +69,13 @@ public class ReplyService {
 		delete(savedReply);
 	}
 
-	public List<ReplyDetailResponse> findAllWithPaging(Long postId, Integer page, Integer size, Long parentId) {
-		validatePageIsNotNegative(page);
-		validateSizeIsNotNegative(size);
+	public List<ReplyDetailResponse> findAllWithPaging(Long postId, Integer requestPage, Integer requestSize, Long parentId) {
+		int page = validatePageIsNotNegative(requestPage);
+		int size = validateSizeIsNotNegative(requestSize);
+		int startRow = calculateStartRow(page, size);
 
 		Post savedPost = postRepository.findById(postId);
-
-		RepliesRequest request = new RepliesRequest(savedPost.getId(), parentId);
+		RepliesRequest request = new RepliesRequest(savedPost.getId(), parentId, startRow, size);
 		List<ReplyResponse> replies = replyRepository.findAll(request);
 
 		return replies.stream()
@@ -93,16 +93,28 @@ public class ReplyService {
 		}
 	}
 
-	private void validatePageIsNotNegative(Integer page) {
+	private int calculateStartRow(int page, int size) {
+		return (page - 1) * size;
+	}
+
+	private int validatePageIsNotNegative(Integer page) {
+		if (page == null) {
+			throw new RuntimeException("page 를 입력해주세요.");
+		}
 		if (page <= 0) {
 			throw new RuntimeException("page 는 1보다 커야합니다.");
 		}
+		return page;
 	}
 
-	private void validateSizeIsNotNegative(Integer size) {
+	private int validateSizeIsNotNegative(Integer size) {
+		if (size == null) {
+			throw new RuntimeException("size 를 입력해주세요.");
+		}
 		if (size <= 0) {
 			throw new RuntimeException("size 는 1보다 커야합니다.");
 		}
+		return size;
 	}
 
 	private void validateReplyBelongToPost(Post savedPost, Reply savedReply) {

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
@@ -81,7 +81,7 @@ public class ReplyService {
 		return replies.stream()
 			.map(reply -> new ReplyDetailResponse(
 				reply.getId(), reply.getNickname(), reply.getContent(), reply.getHeartCount(),
-				dateTimeConvertor.calculate(reply.getCreateDate()), null))
+				dateTimeConvertor.calculate(reply.getCreateDate()), reply.getParentId()))
 			.collect(Collectors.toUnmodifiableList());
 	}
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/ReplyService.java
@@ -29,7 +29,7 @@ public class ReplyService {
 	public ReplyCreateResponse save(Long memberId, Long postId, ReplyCreateRequest request) {
 		Member savedMember = memberRepository.findById(memberId);
 		Post savedPost = postRepository.findById(postId);
-		Reply savedParentReply = replyRepository.findParentById(request);
+		Reply savedParentReply = replyRepository.findParentByParentId(request.getParentId());
 
 		Reply reply = new Reply(request.getContent(), savedParentReply, savedMember);
 		Long parentId = findParentId(savedParentReply);

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/support/DateTimeConvertor.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/support/DateTimeConvertor.java
@@ -1,0 +1,41 @@
+package com.hyundai.hmingle.support;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DateTimeConvertor {
+
+	private static final int SEC = 60;
+	private static final int MIN = 60;
+	private static final int HOUR = 24;
+	private static final int DAY = 30;
+	private static final int MONTH = 12;
+
+	public String calculate(LocalDateTime date) {
+		LocalDateTime now = LocalDateTime.now();
+		long diffTime = date.until(now, ChronoUnit.SECONDS);
+
+		return convert(diffTime);
+	}
+
+	private String convert(long diffTime) {
+		if (diffTime < SEC) {
+			return diffTime + "초 전";
+		} else if ((diffTime /= SEC) < MIN) {
+			return diffTime + "분 전";
+		} else if ((diffTime /= MIN) < HOUR) {
+			return diffTime + "시간 전";
+		} else if ((diffTime /= HOUR) < DAY) {
+			return diffTime + "일 전";
+		} else if ((diffTime /= DAY) < MONTH) {
+			return diffTime + "달 전";
+		}
+		return diffTime + "년 전";
+	}
+}

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
@@ -26,21 +26,29 @@
     </select>
 
     <select id="findAll" resultType="replyResponse">
-        select r.id as id, nickname, content, parent_id
+        select
+            r.id as id, nickname, content, parent_id,
+            (select count(id)
+             from reply_heart
+             where reply_id = r.id)  as heart_count
         from reply r
             left join member m
                 on r.member_id = m.id
         where post_id = #{postId} and parent_id = #{parentId}
-        order by r.id
+        order by r.id desc
     </select>
 
     <select id="findAllIfParentIsNull" resultType="replyResponse">
-        select r.id as id, nickname, content, parent_id
+        select
+            r.id as id, nickname, content, parent_id,
+            (select count(id)
+             from reply_heart
+             where reply_id = r.id)  as heart_count
         from reply r
             left join member m
                 on r.member_id = m.id
         where post_id = #{postId} and parent_id is null
-        order by r.id
+        order by r.id desc
     </select>
 
     <insert id="save" parameterType="map">

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
@@ -30,7 +30,8 @@
             r.id as id, nickname, content, parent_id,
             (select count(id)
              from reply_heart
-             where reply_id = r.id)  as heart_count
+             where reply_id = r.id)  as heart_count,
+            r.created_date as create_date
         from reply r
             left join member m
                 on r.member_id = m.id
@@ -43,7 +44,8 @@
             r.id as id, nickname, content, parent_id,
             (select count(id)
              from reply_heart
-             where reply_id = r.id)  as heart_count
+             where reply_id = r.id)  as heart_count,
+            r.created_date as create_date
         from reply r
             left join member m
                 on r.member_id = m.id

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
@@ -37,6 +37,7 @@
                 on r.member_id = m.id
         where post_id = #{postId} and parent_id = #{parentId}
         order by r.id desc
+        offset #{startRow} rows fetch next #{size} rows only
     </select>
 
     <select id="findAllIfParentIsNull" resultType="replyResponse">
@@ -51,6 +52,7 @@
                 on r.member_id = m.id
         where post_id = #{postId} and parent_id is null
         order by r.id desc
+        offset #{startRow} rows fetch next #{size} rows only
     </select>
 
     <insert id="save" parameterType="map">

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
@@ -25,6 +25,24 @@
         where post_id = #{id}
     </select>
 
+    <select id="findAll" resultType="replyResponse">
+        select r.id as id, nickname, content, parent_id
+        from reply r
+            left join member m
+                on r.member_id = m.id
+        where post_id = #{postId} and parent_id = #{parentId}
+        order by r.id
+    </select>
+
+    <select id="findAllIfParentIsNull" resultType="replyResponse">
+        select r.id as id, nickname, content, parent_id
+        from reply r
+            left join member m
+                on r.member_id = m.id
+        where post_id = #{postId} and parent_id is null
+        order by r.id
+    </select>
+
     <insert id="save" parameterType="map">
         insert into reply (id, content, post_id, member_id, parent_id, depth)
         values (seq_reply_id.nextval, #{content}, #{postId}, #{memberId}, #{parentId}, #{depth})

--- a/H-Mingle/src/main/webapp/WEB-INF/spring/mybatis-config.xml
+++ b/H-Mingle/src/main/webapp/WEB-INF/spring/mybatis-config.xml
@@ -14,13 +14,16 @@
         <typeAlias type="com.hyundai.hmingle.domain.post.Post" alias="post"/>
         <typeAlias type="com.hyundai.hmingle.domain.post.Reply" alias="reply"/>
 
-        <typeAlias type="com.hyundai.hmingle.mapper.dto.request.ReplyUpdateDto" alias="replyUpdateDto"/>
         <typeAlias type="com.hyundai.hmingle.controller.dto.response.ChannelGetResponse" alias="channelGetResponse"/>
         <typeAlias type="com.hyundai.hmingle.controller.dto.request.ImageCreateRequest" alias="imageCreateRequest"/>
         <typeAlias type="com.hyundai.hmingle.controller.dto.request.PostCreateRequest" alias="postCreateRequest"/>
         <typeAlias type="com.hyundai.hmingle.controller.dto.response.MemberGetResponse" alias="memberGetResponse"/>
+
         <typeAlias type="com.hyundai.hmingle.mapper.dto.response.PostDetailResponse" alias="postDetailResponse"/>
+        <typeAlias type="com.hyundai.hmingle.mapper.dto.response.ReplyResponse" alias="replyResponse"/>
+        <typeAlias type="com.hyundai.hmingle.mapper.dto.request.ReplyUpdateDto" alias="replyUpdateDto"/>
         <typeAlias type="com.hyundai.hmingle.mapper.dto.request.PostCreateDto" alias="postCreateDto"/>
         <typeAlias type="com.hyundai.hmingle.mapper.dto.request.PostDeleteDto" alias="postDeleteDto"/>
+        <typeAlias type="com.hyundai.hmingle.mapper.dto.request.RepliesRequest" alias="repliesRequest"/>
     </typeAliases>
 </configuration>


### PR DESCRIPTION
## 📌 개요
- [GET] /posts/{postId}/replies?page=“”&size=“”&parentId=””
  - 게시글의 댓글 목록 조회

## 📝 작업사항
- [x] 페이징 처리
- [x] 생성 일자에 따라 정렬
- [x] 상위 댓글이 없을 경우 모든 최상위 댓글 리스트 조회
- [x] 상위 댓글이 존재할 경우 그에 따른 하위 댓글 리스트 조회
- [x] 작성 일자에 따른 시간 표현 추가
- [x] 댓글 좋아요 수 추가

resolve #49 
