### PR TITLE
[FEATURE] 사용자가 작성한 게시글 리스트 조회 기능 구현

### DIFF
--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/MyPageController.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/MyPageController.java
@@ -1,0 +1,35 @@
+package com.hyundai.hmingle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hyundai.hmingle.controller.dto.response.MingleResponse;
+import com.hyundai.hmingle.controller.dto.response.MyPostsResponse;
+import com.hyundai.hmingle.service.MyPageService;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/members/{memberId}/posts")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyPageController {
+
+	private final MyPageService myPageService;
+
+	@GetMapping
+	public ResponseEntity<MingleResponse<MyPostsResponse>> findPostsWrittenMember(
+		@PathVariable Long memberId,
+		@RequestParam Integer page,
+		@RequestParam Integer size) {
+		MyPostsResponse response = myPageService.findPostsWrittenMember(memberId, page, size);
+		return ResponseEntity.ok(MingleResponse.success(
+			"사용자가 작성한 게시글 목록 조회에 성공하였습니다.",
+			response
+		));
+	}
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/MyPostsResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/MyPostsResponse.java
@@ -1,0 +1,14 @@
+package com.hyundai.hmingle.controller.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MyPostsResponse {
+
+	private final boolean hasNext;
+	private final List<PostsResponse> post;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/PostsResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/PostsResponse.java
@@ -1,0 +1,12 @@
+package com.hyundai.hmingle.controller.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PostsResponse {
+
+	private final long id;
+	private final byte[] image;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ImageMapper.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ImageMapper.java
@@ -3,6 +3,7 @@ package com.hyundai.hmingle.mapper;
 import java.util.List;
 
 import com.hyundai.hmingle.controller.dto.request.ImageCreateRequest;
+import com.hyundai.hmingle.mapper.dto.request.MyPostRequest;
 import com.hyundai.hmingle.mapper.dto.response.MyPostResponse;
 
 public interface ImageMapper {
@@ -11,7 +12,7 @@ public interface ImageMapper {
 
 	List<String> getImages(Long postId);
 
-	List<MyPostResponse> findImageUrlByMemberId(Long memberId);
+	List<MyPostResponse> findImageUrlByMemberId(MyPostRequest request);
 
 	void saveAll(List<ImageCreateRequest> images);
 

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ImageMapper.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/ImageMapper.java
@@ -3,15 +3,17 @@ package com.hyundai.hmingle.mapper;
 import java.util.List;
 
 import com.hyundai.hmingle.controller.dto.request.ImageCreateRequest;
+import com.hyundai.hmingle.mapper.dto.response.MyPostResponse;
 
 public interface ImageMapper {
 	
-	public void saveAll(List<ImageCreateRequest> images);
+	List<String> getFourImages(Long postId);
 
-	public List<String> getFourImages(Long postId);
+	List<String> getImages(Long postId);
 
-	public List<String> getImages(Long postId);
+	List<MyPostResponse> findImageUrlByMemberId(Long memberId);
+
+	void saveAll(List<ImageCreateRequest> images);
 
 	void removeImages(Long postId);
-
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/MyPostRequest.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/request/MyPostRequest.java
@@ -1,0 +1,13 @@
+package com.hyundai.hmingle.mapper.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MyPostRequest {
+
+	private final Long memberId;
+	private final int startRow;
+	private final int size;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/MyPostResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/MyPostResponse.java
@@ -1,0 +1,13 @@
+package com.hyundai.hmingle.mapper.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyPostResponse {
+
+	private final long id;
+	private final String imageUrl;
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ImageRepository.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ImageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import com.hyundai.hmingle.controller.dto.request.ImageCreateRequest;
 import com.hyundai.hmingle.mapper.ImageMapper;
+import com.hyundai.hmingle.mapper.dto.response.MyPostResponse;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,10 @@ public class ImageRepository {
 
 	public List<String> getFourImages(Long postId) {
 		return imageMapper.getFourImages(postId);
+	}
+
+	public List<MyPostResponse> findImageUrlsByMemberId(Long memberId) {
+		return imageMapper.findImageUrlByMemberId(memberId);
 	}
 
 	public void removeImages(Long postId){

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ImageRepository.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/repository/ImageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import com.hyundai.hmingle.controller.dto.request.ImageCreateRequest;
 import com.hyundai.hmingle.mapper.ImageMapper;
+import com.hyundai.hmingle.mapper.dto.request.MyPostRequest;
 import com.hyundai.hmingle.mapper.dto.response.MyPostResponse;
 
 import lombok.AccessLevel;
@@ -25,8 +26,9 @@ public class ImageRepository {
 		return imageMapper.getFourImages(postId);
 	}
 
-	public List<MyPostResponse> findImageUrlsByMemberId(Long memberId) {
-		return imageMapper.findImageUrlByMemberId(memberId);
+	public List<MyPostResponse> findImageUrlsByMemberId(Long memberId, int startRow, int size) {
+		MyPostRequest request = new MyPostRequest(memberId, startRow, size);
+		return imageMapper.findImageUrlByMemberId(request);
 	}
 
 	public void removeImages(Long postId){

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
@@ -1,0 +1,37 @@
+package com.hyundai.hmingle.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hyundai.hmingle.controller.dto.response.MyPostsResponse;
+import com.hyundai.hmingle.controller.dto.response.PostsResponse;
+import com.hyundai.hmingle.domain.member.Member;
+import com.hyundai.hmingle.mapper.dto.response.MyPostResponse;
+import com.hyundai.hmingle.repository.ImageRepository;
+import com.hyundai.hmingle.repository.MemberRepository;
+import com.hyundai.hmingle.support.ImageConvertor;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyPageService {
+
+	private final MemberRepository memberRepository;
+	private final ImageRepository imageRepository;
+	private final ImageConvertor imageConvertor;
+
+	public MyPostsResponse findPostsWrittenMember(Long memberId, Integer page, Integer size) {
+		Member savedMember = memberRepository.findById(memberId);
+		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId());
+		return new MyPostsResponse(false,
+			responses.stream()
+				.map(response -> new PostsResponse(response.getId(), imageConvertor.convertPath(response.getImageUrl())))
+				.collect(Collectors.toUnmodifiableList()));
+	}
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
@@ -34,6 +34,9 @@ public class MyPageService {
 		Member savedMember = memberRepository.findById(memberId);
 		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId(), startRow, size + 1);
 		boolean hasNext = hasNext(size, responses.size());
+		if (hasNext) {
+			responses.remove(responses.size() - 1);
+		}
 		return new MyPostsResponse(hasNext,
 			responses.stream()
 				.map(response -> new PostsResponse(response.getId(), imageConvertor.convertPath(response.getImageUrl())))

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
@@ -26,12 +26,40 @@ public class MyPageService {
 	private final ImageRepository imageRepository;
 	private final ImageConvertor imageConvertor;
 
-	public MyPostsResponse findPostsWrittenMember(Long memberId, Integer page, Integer size) {
+	public MyPostsResponse findPostsWrittenMember(Long memberId, Integer requestPage, Integer requestSize) {
+		int page = validatePageIsNotNegative(requestPage);
+		int size = validateSizeIsNotNegative(requestSize);
+		int startRow = calculateStartRow(page, size);
+
 		Member savedMember = memberRepository.findById(memberId);
-		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId());
+		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId(), startRow, size);
 		return new MyPostsResponse(false,
 			responses.stream()
 				.map(response -> new PostsResponse(response.getId(), imageConvertor.convertPath(response.getImageUrl())))
 				.collect(Collectors.toUnmodifiableList()));
+	}
+
+	private int calculateStartRow(int page, int size) {
+		return (page - 1) * size;
+	}
+
+	private int validatePageIsNotNegative(Integer page) {
+		if (page == null) {
+			throw new RuntimeException("page 를 입력해주세요.");
+		}
+		if (page <= 0) {
+			throw new RuntimeException("page 는 1보다 커야합니다.");
+		}
+		return page;
+	}
+
+	private int validateSizeIsNotNegative(Integer size) {
+		if (size == null) {
+			throw new RuntimeException("size 를 입력해주세요.");
+		}
+		if (size <= 0) {
+			throw new RuntimeException("size 는 1보다 커야합니다.");
+		}
+		return size;
 	}
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/service/MyPageService.java
@@ -32,8 +32,9 @@ public class MyPageService {
 		int startRow = calculateStartRow(page, size);
 
 		Member savedMember = memberRepository.findById(memberId);
-		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId(), startRow, size);
-		return new MyPostsResponse(false,
+		List<MyPostResponse> responses = imageRepository.findImageUrlsByMemberId(savedMember.getId(), startRow, size + 1);
+		boolean hasNext = hasNext(size, responses.size());
+		return new MyPostsResponse(hasNext,
 			responses.stream()
 				.map(response -> new PostsResponse(response.getId(), imageConvertor.convertPath(response.getImageUrl())))
 				.collect(Collectors.toUnmodifiableList()));
@@ -41,6 +42,10 @@ public class MyPageService {
 
 	private int calculateStartRow(int page, int size) {
 		return (page - 1) * size;
+	}
+
+	private boolean hasNext(int requestSize, int responseSize) {
+		return responseSize > requestSize;
 	}
 
 	private int validatePageIsNotNegative(Integer page) {

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
@@ -4,8 +4,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Component;
@@ -21,11 +19,5 @@ public class ImageConvertor {
 		} catch (IOException e) {
 			throw new RuntimeException("이미지를 불러오는데 실패히였습니다.");
 		}
-	}
-
-	public List<byte[]> convertPaths(List<String> paths) {
-		return paths.stream()
-			.map(this::convertPath)
-			.collect(Collectors.toUnmodifiableList());
 	}
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
@@ -1,0 +1,28 @@
+package com.hyundai.hmingle.support;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageConvertor {
+
+	public byte[] convertPath(String path) {
+		try (InputStream imageStream = new FileInputStream(path)) {
+			return IOUtils.toByteArray(imageStream);
+		} catch (IOException e) {
+			throw new RuntimeException("이미지를 불러오는데 실패히였습니다.");
+		}
+	}
+
+	public List<byte[]> convertPaths(List<String> paths) {
+		return paths.stream()
+			.map(this::convertPath)
+			.collect(Collectors.toUnmodifiableList());
+	}
+}

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/support/ImageConvertor.java
@@ -1,6 +1,7 @@
 package com.hyundai.hmingle.support;
 
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -15,6 +16,8 @@ public class ImageConvertor {
 	public byte[] convertPath(String path) {
 		try (InputStream imageStream = new FileInputStream(path)) {
 			return IOUtils.toByteArray(imageStream);
+		} catch (FileNotFoundException e) {
+			return null;
 		} catch (IOException e) {
 			throw new RuntimeException("이미지를 불러오는데 실패히였습니다.");
 		}

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ImageMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ImageMapper.xml
@@ -28,12 +28,14 @@
 	WHERE post_id=#{postId} AND removed=0
 </select>
 
-	<select id="findImageUrlByMemberId" parameterType="long" resultType="myPostResponse">
+	<select id="findImageUrlByMemberId" resultType="myPostResponse">
 		select p.id as id, image_url
 		from post p
 	 		left join image im
 				on p.id = im.post_id
 		where member_id = #{memberId} and orders = 1
+		order by p.id desc
+		offset #{startRow} rows fetch next #{size} rows only
 	</select>
 
 	<update id="removeImages">

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ImageMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ImageMapper.xml
@@ -28,6 +28,14 @@
 	WHERE post_id=#{postId} AND removed=0
 </select>
 
+	<select id="findImageUrlByMemberId" parameterType="long" resultType="myPostResponse">
+		select p.id as id, image_url
+		from post p
+	 		left join image im
+				on p.id = im.post_id
+		where member_id = #{memberId} and orders = 1
+	</select>
+
 	<update id="removeImages">
 		UPDATE image SET removed=1
 		WHERE post_id=#{postId}

--- a/H-Mingle/src/main/webapp/WEB-INF/spring/mybatis-config.xml
+++ b/H-Mingle/src/main/webapp/WEB-INF/spring/mybatis-config.xml
@@ -27,5 +27,6 @@
         <typeAlias type="com.hyundai.hmingle.mapper.dto.request.RepliesRequest" alias="repliesRequest"/>
         <typeAlias type="com.hyundai.hmingle.mapper.dto.response.PostDetailResponse" alias="postDetailResponse"/>
         <typeAlias type="com.hyundai.hmingle.mapper.dto.response.ReplyResponse" alias="replyResponse"/>
+        <typeAlias type="com.hyundai.hmingle.mapper.dto.response.MyPostResponse" alias="myPostResponse"/>
     </typeAliases>
 </configuration>


### PR DESCRIPTION
## 📌 개요
- [GET] /members/{memberId}/posts?page=””&size=””
  - 사용자가 작성한 게시글 리스트 조회 기능 구현

## 📝 작업사항
- [x] 사용자 존재 여부 검증
- [x] 게시글 목록 조회
- [x] 페이징 처리
- [x] hasNext 추가

resolve #54 
