### PR TITLE
[REFACTOR] 댓글 리스트 조회 시 데이터 추가

### DIFF
--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/ReplyController.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/ReplyController.java
@@ -77,11 +77,13 @@ public class ReplyController {
 
 	@GetMapping
 	public ResponseEntity<MingleResponse<List<ReplyDetailResponse>>> findAllWithPaging(
+		@RequestHeader(required = false) HttpHeaders headers,
 		@PathVariable Long postId,
 		@RequestParam Integer page,
 		@RequestParam Integer size,
 		@RequestParam(required = false) Long parentId) {
-		List<ReplyDetailResponse> responses = replyService.findAllWithPaging(postId, page, size, parentId);
+		Long memberId = jwtTokenExtractor.extract(headers);
+		List<ReplyDetailResponse> responses = replyService.findAllWithPaging(memberId, postId, page, size, parentId);
 		return ResponseEntity.ok(MingleResponse.success(
 			"댓글 목록 조회에 성공하였습니다.",
 			responses

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/ReplyDetailResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/controller/dto/response/ReplyDetailResponse.java
@@ -8,9 +8,12 @@ import lombok.RequiredArgsConstructor;
 public class ReplyDetailResponse {
 
 	private final Long id;
+	private final Long memberId;
 	private final String nickname;
 	private final String content;
 	private final int like;
 	private final String recent;
 	private final Long parentId;
+	private final boolean isWriter;
+	private final byte[] image;
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/mapper/dto/response/ReplyResponse.java
@@ -11,9 +11,11 @@ import lombok.NoArgsConstructor;
 public class ReplyResponse {
 
 	private Long id;
+	private Long memberId;
 	private String nickname;
 	private String content;
 	private Long parentId;
 	private int heartCount;
 	private LocalDateTime createDate;
+	private String imageUrl;
 }

--- a/H-Mingle/src/main/java/com/hyundai/hmingle/support/JwtTokenExtractor.java
+++ b/H-Mingle/src/main/java/com/hyundai/hmingle/support/JwtTokenExtractor.java
@@ -21,7 +21,7 @@ public class JwtTokenExtractor {
 	public Long extract(HttpHeaders headers) {
 		List<String> authorizations = headers.get(HttpHeaders.AUTHORIZATION);
 		if (authorizations == null) {
-			throw new RuntimeException("token 이 없습니다.");
+			return null;
 		}
 		String token;
 		for (String authorization : authorizations) {
@@ -33,7 +33,7 @@ public class JwtTokenExtractor {
 				return getPayload(token);
 			}
 		}
-		throw new RuntimeException("헤더에 토큰이 없거나 잘못된 토큰 형식입니다.");
+		throw new RuntimeException("잘못된 토큰 형식입니다.");
 	}
 
 	private boolean isExpired(String token) {

--- a/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
+++ b/H-Mingle/src/main/resources/com/hyundai/hmingle/mapper/ReplyMapper.xml
@@ -27,11 +27,12 @@
 
     <select id="findAll" resultType="replyResponse">
         select
-            r.id as id, nickname, content, parent_id,
+            r.id as id, m.id as member_id, nickname, content, parent_id,
             (select count(id)
              from reply_heart
              where reply_id = r.id)  as heart_count,
-            r.created_date as create_date
+            r.created_date as create_date,
+            m.image_url as image_url
         from reply r
             left join member m
                 on r.member_id = m.id
@@ -42,11 +43,12 @@
 
     <select id="findAllIfParentIsNull" resultType="replyResponse">
         select
-            r.id as id, nickname, content, parent_id,
+            r.id as id, m.id as member_id, nickname, content, parent_id,
             (select count(id)
              from reply_heart
              where reply_id = r.id)  as heart_count,
-            r.created_date as create_date
+            r.created_date as create_date,
+            m.image_url as image_url
         from reply r
             left join member m
                 on r.member_id = m.id


### PR DESCRIPTION
## 📌 개요
- [GET] /posts/{postId}/replies?page=“”&size=“”&parentId=””
  - 댓글 리스트 조회 시 데이터 추가

## 📝 작업사항
- [x] 댓글 작성자 아이디추가
- [x] 댓글 작성자 여부 추가
- [x] 댓글 작성자 프로필 추가

resolve #70 
